### PR TITLE
Fix path for images in the cart drawer

### DIFF
--- a/packages/compiler/package-lock.json
+++ b/packages/compiler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@slater/compiler",
-	"version": "1.3.1",
+	"version": "1.4.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/theme/src/scripts/components/cartDrawer.js
+++ b/packages/theme/src/scripts/components/cartDrawer.js
@@ -16,7 +16,7 @@ function createItem ({
   ...item
 }) {
   const img = image ? getSizedImageUrl(
-    image.replace('_' + imageSize(image), ''), '200x' // TODO hacky af
+    image.replace('.' + imageSize(image), ''), '200x' // TODO hacky af
   ) : 'https://source.unsplash.com/R9OS29xJb-8/2000x1333'
 
   return `


### PR DESCRIPTION
Problem: Images are not visible in the cart drawer.
Solution: update replace from "_" to "."

Yeah, I know.
Still, quite a hacky way but at least images are visible now ;)