### PR TITLE
Clarify how to use ENV vars in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,11 @@ module.exports = {
   alias: {
     components: './src/scripts/components'
   },
-  env: {
-    API_KEY: 'abcde...'
-  }
+  assets: {
+    env: {
+      API_KEY: JSON.stringify('abcde'),
+    }
+  },
 }
 ```
 


### PR DESCRIPTION
Issue: https://github.com/the-couch/slater/issues/28

The `env` object needs to be nested within the 
`assets` object at this time. 

Additionally, since the ENV var is injected by 
Webpack’s Define Plugin, a string value must 
include actual quotes, or JSON.stringify(). 
See more at https://webpack.js.org/plugins/define-plugin/