### PR TITLE
Add progress bar to sync...

### DIFF
--- a/packages/slater/cli.js
+++ b/packages/slater/cli.js
@@ -60,7 +60,7 @@ prog
         .sync(paths, (total, rest) => {
           const complete = total - rest
           const percent = Math.ceil((complete / total) * 100)
-          log.info('syncing', percent + '%', true)
+          log.progress('upload','syncing', percent)
         })
     ])
       .then(() => {

--- a/packages/sync/cli.js
+++ b/packages/sync/cli.js
@@ -31,7 +31,7 @@ prog
         .sync(paths, (total, rest) => {
           const complete = total - rest
           const percent = Math.ceil((complete / total) * 100)
-          log.info('syncing', percent + '%', true)
+          log.progress('upload', 'syncing', percent)
         })
     ])
       .then(() => {

--- a/packages/util/logger.js
+++ b/packages/util/logger.js
@@ -1,5 +1,6 @@
 const c = require('ansi-colors')
 const write = require('log-update')
+const progress = require('./progress')
 const log = console.log
 
 module.exports = function logger (scope) {
@@ -26,6 +27,13 @@ module.exports = function logger (scope) {
     error (message) {
       write([
         c.red('error') + ' ' + (message || '')
+      ].filter(Boolean).join(' '))
+    },
+    progress (theme, action, percentage) {
+      write([
+        c.gray(scope),
+        c.blue(action + '\n\n'),
+        progress[theme](percentage)
       ].filter(Boolean).join(' '))
     }
   }

--- a/packages/util/progress.js
+++ b/packages/util/progress.js
@@ -1,0 +1,25 @@
+module.exports = progress = {
+    upload: (() => {
+        const path = '·························'
+        const earth = ['🌏', '🌍', '🌎']
+        const home = '🏡'
+        const payload = '📦'
+        let earthFrame = 0
+
+        return percentage => {
+            const payloadPos = Math.ceil(path.length * (percentage / 100)) - 1
+            const newPath = path.substr(0, payloadPos) + payload + ' ' + path.substr(payloadPos + 1)
+
+            earthFrame = earthFrame === 2 ? 0 : earthFrame + 1
+
+            const padLength = 3 - percentage.toString().length
+            let pad = ''
+
+            for (let i = 0; i < padLength + 2; i++) {
+                pad += '\u00A0'
+            }
+
+            return home + '  ' + newPath + ' ' + earth[earthFrame] + pad + percentage + '%'
+        }
+    })()
+}


### PR DESCRIPTION
... and mildly prepare support for other potential progress bars throughout the CLI.

After talking to @estrattonbailey on Slack I felt like contributing with something. Since the roadmap is till being mapped out, I figured I could do something a bit more fluffy for now. Enter the progress bar! 

The logger has gotten another log type `log.progress()`, that uses the helper `progress.js`.

I have given `log.progress()` an argument called `theme`: got the inspiration from the `unsync` command and figured it might be useful to be able to define different progress bars for different commands in the future.