### PR TITLE
update sanitize.js to support new sections paradigm. 

### DIFF
--- a/packages/util/sanitize.js
+++ b/packages/util/sanitize.js
@@ -3,7 +3,7 @@ module.exports = function sanitize (p) {
   if (/^\//.test(p)) {
     return sanitize(p.substr(1))
   }
-  if (!/^(layout|templates|sections|snippets|config|locales|assets)/.test(p)) {
+  if (!/^(layout|content|frame|pages|templates|sections|snippets|config|locales|assets)/.test(p)) {
     return sanitize(p.split('/').slice(1).join('/'))
   }
   return p


### PR DESCRIPTION
This enables `frame/`, `content/`, and` pages/` directories to be allowed to sync.

Reference: [New Sections Paradigm](https://help.shopify.com/en/themes/development/section-themes)

Right now, I believe this will only work with nontransferable [development-stores](https://help.shopify.com/en/partners/dashboard/development-stores) that have the developer preview enabled.
