### PR TITLE
feature: test if store/theme are valid and password is valid

### DIFF
--- a/packages/slater/cli.js
+++ b/packages/slater/cli.js
@@ -55,14 +55,22 @@ prog
 
     paths = paths && paths.length ? paths : config.out
 
-    wait(1000, [
-      theme
-        .sync(paths, (total, rest) => {
-          const complete = total - rest
-          const percent = Math.ceil((complete / total) * 100)
-          log.progress('upload','syncing', percent)
-        })
-    ])
+    theme
+      .test()
+      .catch(({ errors }) => {
+        log.error(errors)
+        exit()
+      })
+      .then(() =>
+        wait(1000, [
+          theme
+            .sync(paths, (total, rest) => {
+              const complete = total - rest
+              const percent = Math.ceil((complete / total) * 100)
+              log.progress('upload','syncing', percent)
+            })
+        ])
+      )
       .then(() => {
         log.info(
           'synced',
@@ -94,14 +102,22 @@ prog
 
     paths = paths && paths.length ? paths : config.out
 
-    wait(1000, [
-      theme
-        .unsync(paths, (total, rest) => {
-          const complete = total - rest
-          const percent = Math.ceil((complete / total) * 100)
-          log.info('unsyncing', percent + '%', true)
-        })
-    ])
+    theme
+      .test()
+      .catch(({ errors }) => {
+        log.error(errors)
+        exit()
+      })
+      .then(() =>
+        wait(1000, [
+          theme
+            .unsync(paths, (total, rest) => {
+              const complete = total - rest
+              const percent = Math.ceil((complete / total) * 100)
+              log.info('unsyncing', percent + '%', true)
+            })
+        ])
+      )
       .then(() => {
         log.info(
           'unsynced',

--- a/packages/sync/index.js
+++ b/packages/sync/index.js
@@ -55,6 +55,24 @@ module.exports = function init (config) {
     })
   }
 
+  function test () {
+    return api('GET', undefined)
+      .then(res => {
+        if (res.status === 404) {
+          throw {
+            errors: `No theme found with id '${config.id}'`
+          }
+        }
+        return res.json()
+      })
+      .then(({ errors, ...rest }) => {
+        if (errors) {
+          throw {errors}
+        }
+        return rest
+      })
+  }
+
   function upload ({ key, file }) {
     const encoded = Buffer.from(fs.readFileSync(file), 'utf-8').toString('base64')
 
@@ -208,6 +226,7 @@ module.exports = function init (config) {
   return {
     sync,
     unsync,
-    config
+    config,
+    test
   }
 }


### PR DESCRIPTION
before issuing more sync or unsync requests.

Provides a nicer error message: 

1. wrong api key
`error [API] Invalid API key or access token (unrecognized login or wrong password)`

2. wrong theme id
`error No theme found with id 'aaa74961715260aaaa'`

closes the-couch/slater#55
closes the-couch/slater#51