### PR TITLE
make sass compiler ignore urls

### DIFF
--- a/packages/compiler/presets/sass.js
+++ b/packages/compiler/presets/sass.js
@@ -8,7 +8,12 @@ module.exports = (options = {}) => {
       exclude: /node_modules/,
       use: [
         ExtractCSS.loader,
-        require.resolve('css-loader'),
+        {
+          loader: require.resolve('css-loader'),
+          options: {
+            url: false
+          }
+        },
         {
           loader: require.resolve('postcss-loader'),
           options: {


### PR DESCRIPTION
This makes it possible to use relative urls in the .scss files as explained in here #27 

**Code example:**
`background: url('close.svg') center / contain;`
_This line would grab the close.svg, inside of the assets folder_