### PR TITLE
Typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A new toolkit for building and deploying themes on Shopify.
   - [Themes](#themes)
   - [Directory Structure](#directory-structure)
   - [Assets](#assets)
+  - [Typescript](#typescript)
   - [Alias & Env](#alias--env)
 - [Command Line](#command-line)
   - [watch](#watch)
@@ -199,6 +200,45 @@ module.exports = {
   }
 }
 ```
+
+### Typescript
+Specify `typescript` preset in your assets config to enable Typescript support:
+```javascript
+module.exports = {
+    in: '/src/scripts/index.js'
+  assets: {
+    presets: [
+      'typescript'
+    ]
+  }
+}
+```
+
+Then add `index.ts` file to `/src/scripts/` folder and modify your entry js file (`/src/scripts/index.js` by default) to import new typescript entry file:
+```javascript
+import '../index.ts' // path to your entry .ts file
+
+// rest of your project scripts
+```
+
+You can copy rest of the projects scripts and styles import to typescript file. Last step is to add `tsconfig.json` file to the root of your project:
+```json
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "react",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": false,
+    "target": "es2015",
+    "experimentalDecorators": true,
+  },
+  "exclude": ["node_modules", "slater.config.js", "test.config.js"]
+}
+```
+
 
 ### Alias & Env
 To make your JavaScript a little easier to work with, Slater supports alias

--- a/README.md
+++ b/README.md
@@ -216,12 +216,12 @@ module.exports = {
 
 Then add `index.ts` file to `/src/scripts/` folder and modify your entry js file (`/src/scripts/index.js` by default) to import new typescript entry file:
 ```javascript
-import '../index.ts' // path to your entry .ts file
+import './index.ts' // path to your entry .ts file
 
 // rest of your project scripts
 ```
 
-You can copy rest of the projects scripts and styles import to typescript file. Last step is to add `tsconfig.json` file to the root of your project:
+You can copy rest of the projects scripts and styles import to typescript file, leaving only one import line in js file. Last step is to add `tsconfig.json` file to the root of your project:
 ```json
 {
   "compilerOptions": {
@@ -232,13 +232,11 @@ You can copy rest of the projects scripts and styles import to typescript file. 
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": false,
-    "target": "es2015",
-    "experimentalDecorators": true,
+    "target": "es2015"
   },
   "exclude": ["node_modules", "slater.config.js", "test.config.js"]
 }
 ```
-
 
 ### Alias & Env
 To make your JavaScript a little easier to work with, Slater supports alias

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -45,6 +45,8 @@
     "sass-loader": "^7.1.0",
     "socket.io": "^2.2.0",
     "style-loader": "^0.20.3",
+    "ts-loader": "^6.2.1",
+    "typescript": "^3.7.5",
     "webpack": "^4.33.0"
   },
   "gitHead": "5068db0b2661b5e4a94a7a439e5919c4cc13c837"

--- a/packages/compiler/presets/typescript.js
+++ b/packages/compiler/presets/typescript.js
@@ -1,0 +1,11 @@
+module.exports = (options = {}) => {
+  return function createConfig ({ config, watch }) {
+    config.module.rules.push({
+      test: /\.(ts|tsx)$/,
+      exclude: /node_modules/,
+      loader: require.resolve('ts-loader')
+    })
+
+    return config
+  }
+}

--- a/packages/slater/package.json
+++ b/packages/slater/package.json
@@ -39,6 +39,8 @@
     "terminal-link": "^1.2.0",
     "unzipper": "^0.9.10",
     "w2t": "0.0.2",
+    "ts-loader": "^6.2.1",
+    "typescript": "^3.7.5",
     "webpack": "^4.26.0",
     "yaml": "^1.0.0-rc.7"
   },


### PR DESCRIPTION
A couple of changes to enable Typescript support for theme scripts. Similar to SASS it can be enabled through config file (step by step guide with default config added to readme).