### PR TITLE
Upgrade compiler to use postcss-preset-env

### DIFF
--- a/packages/compiler/package-lock.json
+++ b/packages/compiler/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@slater/compiler",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1151,6 +1151,11 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@csstools/convert-colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
+		},
 		"@types/q": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -1499,56 +1504,66 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"autoprefixer": {
-			"version": "9.6.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz",
-			"integrity": "sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+			"integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
 			"requires": {
-				"browserslist": "^4.6.1",
-				"caniuse-lite": "^1.0.30000971",
+				"browserslist": "^4.8.3",
+				"caniuse-lite": "^1.0.30001020",
 				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.16",
-				"postcss-value-parser": "^3.3.1"
+				"postcss": "^7.0.26",
+				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.6.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
-					"integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30000971",
-						"electron-to-chromium": "^1.3.137",
-						"node-releases": "^1.1.21"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30000974",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
-					"integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww=="
+					"version": "1.0.30001025",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
+					"integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ=="
 				},
 				"electron-to-chromium": {
-					"version": "1.3.149",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.149.tgz",
-					"integrity": "sha512-XO+s6imdgjUS5hHDwh31fpkzxiIz7hFX8B5qnJdlP/BnzqqDF2A/YoitbGt5TknCm8dS9tIYdiXwDbarsonaFA=="
+					"version": "1.3.345",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
+					"integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg=="
 				},
 				"node-releases": {
-					"version": "1.1.23",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
-					"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+					"version": "1.1.48",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
+					"integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
 					"requires": {
-						"semver": "^5.3.0"
+						"semver": "^6.3.0"
 					}
 				},
 				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
+					"version": "7.0.26",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+					"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
 					"requires": {
 						"chalk": "^2.4.2",
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
+				},
+				"postcss-value-parser": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -1576,31 +1591,10 @@
 				"pify": "^4.0.1"
 			}
 		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-					"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
-				}
-			}
-		},
 		"backo2": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
 			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-		},
-		"balanced-match": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-			"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
 		},
 		"base": {
 			"version": "0.11.2",
@@ -2285,53 +2279,12 @@
 				"randomfill": "^1.0.3"
 			}
 		},
-		"css-color-function": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
-			"integrity": "sha1-jtJMLAIFBzM5+voAS8jBQfzLKC4=",
+		"css-blank-pseudo": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+			"integrity": "sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==",
 			"requires": {
-				"balanced-match": "0.1.0",
-				"color": "^0.11.0",
-				"debug": "^3.1.0",
-				"rgb": "~0.1.0"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
-					"integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo="
-				},
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-				},
-				"color": {
-					"version": "0.11.4",
-					"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-					"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-					"requires": {
-						"clone": "^1.0.2",
-						"color-convert": "^1.3.0",
-						"color-string": "^0.3.0"
-					}
-				},
-				"color-string": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-					"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-					"requires": {
-						"color-name": "^1.0.0"
-					}
-				},
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"postcss": "^7.0.5"
 			}
 		},
 		"css-color-names": {
@@ -2346,6 +2299,32 @@
 			"requires": {
 				"postcss": "^7.0.1",
 				"timsort": "^0.3.0"
+			}
+		},
+		"css-has-pseudo": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+			"integrity": "sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==",
+			"requires": {
+				"postcss": "^7.0.6",
+				"postcss-selector-parser": "^5.0.0-rc.4"
+			},
+			"dependencies": {
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+					"requires": {
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
 			}
 		},
 		"css-loader": {
@@ -2364,6 +2343,14 @@
 				"postcss-modules-values": "^2.0.0",
 				"postcss-value-parser": "^3.3.0",
 				"schema-utils": "^1.0.0"
+			}
+		},
+		"css-prefers-color-scheme": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+			"integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
+			"requires": {
+				"postcss": "^7.0.5"
 			}
 		},
 		"css-select": {
@@ -2405,6 +2392,11 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+		},
+		"cssdb": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
+			"integrity": "sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ=="
 		},
 		"cssesc": {
 			"version": "3.0.0",
@@ -4067,11 +4059,6 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
-		"isnumeric": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
-			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ="
-		},
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -4195,15 +4182,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
 			"integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
 		},
-		"lodash.template": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-			"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-			"requires": {
-				"lodash._reinterpolate": "~3.0.0",
-				"lodash.templatesettings": "^4.0.0"
-			}
-		},
 		"lodash.templatesettings": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
@@ -4259,11 +4237,6 @@
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
-		},
-		"math-expression-evaluator": {
-			"version": "1.2.17",
-			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
-			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
 		},
 		"md5.js": {
 			"version": "1.3.5",
@@ -4643,11 +4616,6 @@
 				"wrappy": "1"
 			}
 		},
-		"onecolor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/onecolor/-/onecolor-3.1.0.tgz",
-			"integrity": "sha512-YZSypViXzu3ul5LMu/m6XjJ9ol8qAy9S2VjHl5E6UlhUH1KGKWabyEJifn0Jjpw23bYDzC2ucKMPGiH5kfwSGQ=="
-		},
 		"optimize-css-assets-webpack-plugin": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
@@ -4783,74 +4751,12 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
 		},
-		"pixrem": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pixrem/-/pixrem-4.0.1.tgz",
-			"integrity": "sha1-LaSh3m7EQjxfw3lOkwuB1EkOxoY=",
-			"requires": {
-				"browserslist": "^2.0.0",
-				"postcss": "^6.0.0",
-				"reduce-css-calc": "^1.2.7"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "2.11.3",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-					"requires": {
-						"caniuse-lite": "^1.0.30000792",
-						"electron-to-chromium": "^1.3.30"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"pkg-dir": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"requires": {
 				"find-up": "^3.0.0"
-			}
-		},
-		"pleeease-filters": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/pleeease-filters/-/pleeease-filters-4.0.0.tgz",
-			"integrity": "sha1-ZjKy+wVkjSdY2GU4T7zteeHMrsc=",
-			"requires": {
-				"onecolor": "^3.0.4",
-				"postcss": "^6.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
 			}
 		},
 		"pocket.io": {
@@ -4892,69 +4798,6 @@
 				}
 			}
 		},
-		"postcss-apply": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.8.0.tgz",
-			"integrity": "sha1-FOVEu7XLbxweBIhXll15rgZrE0M=",
-			"requires": {
-				"babel-runtime": "^6.23.0",
-				"balanced-match": "^0.4.2",
-				"postcss": "^6.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-attribute-case-insensitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-2.0.0.tgz",
-			"integrity": "sha1-lNxCLI+QmX8WvTOjZUu77AhJY7Q=",
-			"requires": {
-				"postcss": "^6.0.0",
-				"postcss-selector-parser": "^2.2.3"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"postcss-selector-parser": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-					"requires": {
-						"flatten": "^1.0.2",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"postcss-calc": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
@@ -4983,247 +4826,46 @@
 				}
 			}
 		},
-		"postcss-color-function": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-function/-/postcss-color-function-4.1.0.tgz",
-			"integrity": "sha512-2/fuv6mP5Lt03XbRpVfMdGC8lRP1sykme+H1bR4ARyOmSMB8LPSjcL6EAI1iX6dqUF+jNEvKIVVXhan1w/oFDQ==",
+		"postcss-color-functional-notation": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+			"integrity": "sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==",
 			"requires": {
-				"css-color-function": "~1.3.3",
-				"postcss": "^6.0.23",
-				"postcss-message-helpers": "^2.0.0",
-				"postcss-value-parser": "^3.3.1"
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-color-gray": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-4.1.0.tgz",
-			"integrity": "sha512-L4iLKQLdqChz6ZOgGb6dRxkBNw78JFYcJmBz1orHpZoeLtuhDDGegRtX9gSyfoCIM7rWZ3VNOyiqqvk83BEN+w==",
-			"requires": {
-				"color": "^2.0.1",
-				"postcss": "^6.0.14",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-function-call": "^1.0.2"
-			},
-			"dependencies": {
-				"color": {
+				"postcss-values-parser": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color/-/color-2.0.1.tgz",
-					"integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"color-convert": "^1.9.1",
-						"color-string": "^1.5.2"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"postcss-color-hex-alpha": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-3.0.0.tgz",
-			"integrity": "sha1-HlPmyKyyN5Vej9CLfs2xuLgwn5U=",
+		"postcss-color-mod-function": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+			"integrity": "sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==",
 			"requires": {
-				"color": "^1.0.3",
-				"postcss": "^6.0.1",
-				"postcss-message-helpers": "^2.0.0"
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"color": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-					"integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"color-convert": "^1.8.2",
-						"color-string": "^1.4.0"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-color-hsl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hsl/-/postcss-color-hsl-2.0.0.tgz",
-			"integrity": "sha1-EnA2ZvoxBDDj8wpFTawThjF9WEQ=",
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-value-parser": "^3.3.0",
-				"units-css": "^0.4.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-color-hwb": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-hwb/-/postcss-color-hwb-3.0.0.tgz",
-			"integrity": "sha1-NAKxnvTYSXVAwftQcr6YY8qVVx4=",
-			"requires": {
-				"color": "^1.0.3",
-				"postcss": "^6.0.1",
-				"postcss-message-helpers": "^2.0.0",
-				"reduce-function-call": "^1.0.2"
-			},
-			"dependencies": {
-				"color": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
-					"integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
-					"requires": {
-						"color-convert": "^1.8.2",
-						"color-string": "^1.4.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-color-rebeccapurple": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-3.1.0.tgz",
-			"integrity": "sha512-212hJUk9uSsbwO5ECqVjmh/iLsmiVL1xy9ce9TVf+X3cK/ZlUIlaMdoxje/YpsL9cmUH3I7io+/G2LyWx5rg1g==",
-			"requires": {
-				"postcss": "^6.0.22",
-				"postcss-values-parser": "^1.5.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-color-rgb": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rgb/-/postcss-color-rgb-2.0.0.tgz",
-			"integrity": "sha1-FFOcinExSUtILg3RzCZf9lFLUmM=",
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-value-parser": "^3.3.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-color-rgba-fallback": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-color-rgba-fallback/-/postcss-color-rgba-fallback-3.0.0.tgz",
-			"integrity": "sha1-N9XJNToHoJJwkSqCYGu0Kg1wLAQ=",
-			"requires": {
-				"postcss": "^6.0.6",
-				"postcss-value-parser": "^3.3.0",
-				"rgb-hex": "^2.1.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -5248,223 +4890,29 @@
 				"postcss-value-parser": "^3.0.0"
 			}
 		},
-		"postcss-cssnext": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz",
-			"integrity": "sha512-awPDhI4OKetcHCr560iVCoDuP6e/vn0r6EAqdWPpAavJMvkBSZ6kDpSN4b3mB3Ti57hQMunHHM8Wvx9PeuYXtA==",
+		"postcss-dir-pseudo-class": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+			"integrity": "sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==",
 			"requires": {
-				"autoprefixer": "^7.1.1",
-				"caniuse-api": "^2.0.0",
-				"chalk": "^2.0.1",
-				"pixrem": "^4.0.0",
-				"pleeease-filters": "^4.0.0",
-				"postcss": "^6.0.5",
-				"postcss-apply": "^0.8.0",
-				"postcss-attribute-case-insensitive": "^2.0.0",
-				"postcss-calc": "^6.0.0",
-				"postcss-color-function": "^4.0.0",
-				"postcss-color-gray": "^4.0.0",
-				"postcss-color-hex-alpha": "^3.0.0",
-				"postcss-color-hsl": "^2.0.0",
-				"postcss-color-hwb": "^3.0.0",
-				"postcss-color-rebeccapurple": "^3.0.0",
-				"postcss-color-rgb": "^2.0.0",
-				"postcss-color-rgba-fallback": "^3.0.0",
-				"postcss-custom-media": "^6.0.0",
-				"postcss-custom-properties": "^6.1.0",
-				"postcss-custom-selectors": "^4.0.1",
-				"postcss-font-family-system-ui": "^3.0.0",
-				"postcss-font-variant": "^3.0.0",
-				"postcss-image-set-polyfill": "^0.3.5",
-				"postcss-initial": "^2.0.0",
-				"postcss-media-minmax": "^3.0.0",
-				"postcss-nesting": "^4.0.1",
-				"postcss-pseudo-class-any-link": "^4.0.0",
-				"postcss-pseudoelements": "^5.0.0",
-				"postcss-replace-overflow-wrap": "^2.0.0",
-				"postcss-selector-matches": "^3.0.1",
-				"postcss-selector-not": "^3.0.1"
+				"postcss": "^7.0.2",
+				"postcss-selector-parser": "^5.0.0-rc.3"
 			},
 			"dependencies": {
-				"autoprefixer": {
-					"version": "7.2.6",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-					"integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
-					"requires": {
-						"browserslist": "^2.11.3",
-						"caniuse-lite": "^1.0.30000805",
-						"normalize-range": "^0.1.2",
-						"num2fraction": "^1.2.2",
-						"postcss": "^6.0.17",
-						"postcss-value-parser": "^3.2.3"
-					}
-				},
-				"browserslist": {
-					"version": "2.11.3",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-					"integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-					"requires": {
-						"caniuse-lite": "^1.0.30000792",
-						"electron-to-chromium": "^1.3.30"
-					}
-				},
-				"caniuse-api": {
+				"cssesc": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-2.0.0.tgz",
-					"integrity": "sha1-sd21pZZrFvSNxJmERNS7xsfZ2DQ=",
-					"requires": {
-						"browserslist": "^2.0.0",
-						"caniuse-lite": "^1.0.0",
-						"lodash.memoize": "^4.1.2",
-						"lodash.uniq": "^4.5.0"
-					}
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"postcss-calc": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-6.0.2.tgz",
-					"integrity": "sha512-fiznXjEN5T42Qm7qqMCVJXS3roaj9r4xsSi+meaBVe7CJBl8t/QLOXu02Z2E6oWAMWIvCuF6JrvzFekmVEbOKA==",
-					"requires": {
-						"css-unit-converter": "^1.1.1",
-						"postcss": "^7.0.2",
-						"postcss-selector-parser": "^2.2.2",
-						"reduce-css-calc": "^2.0.0"
-					},
-					"dependencies": {
-						"postcss": {
-							"version": "7.0.14",
-							"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-							"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-							"requires": {
-								"chalk": "^2.4.2",
-								"source-map": "^0.6.1",
-								"supports-color": "^6.1.0"
-							}
-						},
-						"supports-color": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-							"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
 				},
 				"postcss-selector-parser": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
 					"requires": {
-						"flatten": "^1.0.2",
+						"cssesc": "^2.0.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
-				},
-				"reduce-css-calc": {
-					"version": "2.1.6",
-					"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.6.tgz",
-					"integrity": "sha512-+l5/qlQmdsbM9h6JerJ/y5vR5Ci0k93aszLNpCmbadC3nBcbRGmIBm0s9Nj59i22LvCjTGftWzdQRwdknayxhw==",
-					"requires": {
-						"css-unit-converter": "^1.1.1",
-						"postcss-value-parser": "^3.3.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-custom-media": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz",
-			"integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
-			"requires": {
-				"postcss": "^6.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-custom-properties": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.3.1.tgz",
-			"integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
-			"requires": {
-				"balanced-match": "^1.0.0",
-				"postcss": "^6.0.18"
-			},
-			"dependencies": {
-				"balanced-match": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-				},
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-custom-selectors": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-4.0.1.tgz",
-			"integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
-			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-selector-matches": "^3.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -5500,79 +4948,90 @@
 				"postcss": "^7.0.0"
 			}
 		},
-		"postcss-font-family-system-ui": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-3.0.0.tgz",
-			"integrity": "sha512-58G/hTxMSSKlIRpcPUjlyo6hV2MEzvcVO2m4L/T7Bb2fJTG4DYYfQjQeRvuimKQh1V1sOzCIz99g+H2aFNtlQw==",
+		"postcss-double-position-gradients": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+			"integrity": "sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==",
 			"requires": {
-				"postcss": "^6.0"
+				"postcss": "^7.0.5",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"postcss-font-variant": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-3.0.0.tgz",
-			"integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
+		"postcss-env-function": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+			"integrity": "sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==",
 			"requires": {
-				"postcss": "^6.0.1"
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
-		"postcss-image-set-polyfill": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/postcss-image-set-polyfill/-/postcss-image-set-polyfill-0.3.5.tgz",
-			"integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
+		"postcss-focus-visible": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+			"integrity": "sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==",
 			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-media-query-parser": "^0.2.3"
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-focus-within": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+			"integrity": "sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==",
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-gap-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+			"integrity": "sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==",
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-image-set-function": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+			"integrity": "sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -5587,52 +5046,35 @@
 				"resolve": "^1.1.7"
 			}
 		},
-		"postcss-initial": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-2.0.0.tgz",
-			"integrity": "sha1-cnFfczbgu3k1HZnuZcSiU6hEG6Q=",
+		"postcss-lab-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+			"integrity": "sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==",
 			"requires": {
-				"lodash.template": "^4.2.4",
-				"postcss": "^6.0.1"
+				"@csstools/convert-colors": "^1.4.0",
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
 		"postcss-load-config": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+			"integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
 			"requires": {
-				"cosmiconfig": "^4.0.0",
+				"cosmiconfig": "^5.0.0",
 				"import-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.9.0",
-						"parse-json": "^4.0.0",
-						"require-from-string": "^2.0.1"
-					}
-				}
 			}
 		},
 		"postcss-loader": {
@@ -5646,35 +5088,13 @@
 				"schema-utils": "^1.0.0"
 			}
 		},
-		"postcss-media-minmax": {
+		"postcss-logical": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz",
-			"integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
+			"resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-3.0.0.tgz",
+			"integrity": "sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==",
 			"requires": {
-				"postcss": "^6.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
+				"postcss": "^7.0.2"
 			}
-		},
-		"postcss-media-query-parser": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
 		},
 		"postcss-merge-longhand": {
 			"version": "4.0.11",
@@ -5711,11 +5131,6 @@
 					}
 				}
 			}
-		},
-		"postcss-message-helpers": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
-			"integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4="
 		},
 		"postcss-minify-font-values": {
 			"version": "4.0.2",
@@ -5845,31 +5260,6 @@
 				}
 			}
 		},
-		"postcss-nesting": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-4.2.1.tgz",
-			"integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
-			"requires": {
-				"postcss": "^6.0.11"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
 		"postcss-normalize-charset": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
@@ -5970,64 +5360,347 @@
 				"postcss-value-parser": "^3.0.0"
 			}
 		},
-		"postcss-pseudo-class-any-link": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-4.0.0.tgz",
-			"integrity": "sha1-kVKgYT00UHIFE+iJKFS65C0O5o4=",
+		"postcss-overflow-shorthand": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+			"integrity": "sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==",
 			"requires": {
-				"postcss": "^6.0.1",
-				"postcss-selector-parser": "^2.2.3"
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-page-break": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+			"integrity": "sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==",
+			"requires": {
+				"postcss": "^7.0.2"
+			}
+		},
+		"postcss-place": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-4.0.1.tgz",
+			"integrity": "sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==",
+			"requires": {
+				"postcss": "^7.0.2",
+				"postcss-values-parser": "^2.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
+						"flatten": "^1.0.2",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
+			}
+		},
+		"postcss-preset-env": {
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
+			"integrity": "sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==",
+			"requires": {
+				"autoprefixer": "^9.6.1",
+				"browserslist": "^4.6.4",
+				"caniuse-lite": "^1.0.30000981",
+				"css-blank-pseudo": "^0.1.4",
+				"css-has-pseudo": "^0.10.0",
+				"css-prefers-color-scheme": "^3.1.1",
+				"cssdb": "^4.4.0",
+				"postcss": "^7.0.17",
+				"postcss-attribute-case-insensitive": "^4.0.1",
+				"postcss-color-functional-notation": "^2.0.1",
+				"postcss-color-gray": "^5.0.0",
+				"postcss-color-hex-alpha": "^5.0.3",
+				"postcss-color-mod-function": "^3.0.3",
+				"postcss-color-rebeccapurple": "^4.0.1",
+				"postcss-custom-media": "^7.0.8",
+				"postcss-custom-properties": "^8.0.11",
+				"postcss-custom-selectors": "^5.1.2",
+				"postcss-dir-pseudo-class": "^5.0.0",
+				"postcss-double-position-gradients": "^1.0.0",
+				"postcss-env-function": "^2.0.2",
+				"postcss-focus-visible": "^4.0.0",
+				"postcss-focus-within": "^3.0.0",
+				"postcss-font-variant": "^4.0.0",
+				"postcss-gap-properties": "^2.0.0",
+				"postcss-image-set-function": "^3.0.1",
+				"postcss-initial": "^3.0.0",
+				"postcss-lab-function": "^2.0.1",
+				"postcss-logical": "^3.0.0",
+				"postcss-media-minmax": "^4.0.0",
+				"postcss-nesting": "^7.0.0",
+				"postcss-overflow-shorthand": "^2.0.0",
+				"postcss-page-break": "^2.0.0",
+				"postcss-place": "^4.0.1",
+				"postcss-pseudo-class-any-link": "^6.0.0",
+				"postcss-replace-overflow-wrap": "^3.0.0",
+				"postcss-selector-matches": "^4.0.0",
+				"postcss-selector-not": "^4.0.0"
+			},
+			"dependencies": {
+				"autoprefixer": {
+					"version": "9.7.4",
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+					"integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
+					"requires": {
+						"browserslist": "^4.8.3",
+						"caniuse-lite": "^1.0.30001020",
+						"chalk": "^2.4.2",
+						"normalize-range": "^0.1.2",
+						"num2fraction": "^1.2.2",
+						"postcss": "^7.0.26",
+						"postcss-value-parser": "^4.0.2"
+					},
+					"dependencies": {
+						"postcss": {
+							"version": "7.0.26",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+							"integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+							"requires": {
+								"chalk": "^2.4.2",
+								"source-map": "^0.6.1",
+								"supports-color": "^6.1.0"
+							}
+						}
 					}
 				},
-				"postcss-selector-parser": {
-					"version": "2.2.3",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-					"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+				"balanced-match": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+				},
+				"browserslist": {
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+					"requires": {
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001025",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
+					"integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ=="
+				},
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.345",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
+					"integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg=="
+				},
+				"lodash.template": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+					"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+					"requires": {
+						"lodash._reinterpolate": "^3.0.0",
+						"lodash.templatesettings": "^4.0.0"
+					}
+				},
+				"node-releases": {
+					"version": "1.1.48",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
+					"integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
+					"requires": {
+						"semver": "^6.3.0"
+					}
+				},
+				"postcss-attribute-case-insensitive": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz",
+					"integrity": "sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==",
+					"requires": {
+						"postcss": "^7.0.2",
+						"postcss-selector-parser": "^6.0.2"
+					}
+				},
+				"postcss-color-gray": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+					"integrity": "sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==",
+					"requires": {
+						"@csstools/convert-colors": "^1.4.0",
+						"postcss": "^7.0.5",
+						"postcss-values-parser": "^2.0.0"
+					}
+				},
+				"postcss-color-hex-alpha": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+					"integrity": "sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==",
+					"requires": {
+						"postcss": "^7.0.14",
+						"postcss-values-parser": "^2.0.1"
+					}
+				},
+				"postcss-color-rebeccapurple": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+					"integrity": "sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==",
+					"requires": {
+						"postcss": "^7.0.2",
+						"postcss-values-parser": "^2.0.0"
+					}
+				},
+				"postcss-custom-media": {
+					"version": "7.0.8",
+					"resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+					"integrity": "sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==",
+					"requires": {
+						"postcss": "^7.0.14"
+					}
+				},
+				"postcss-custom-properties": {
+					"version": "8.0.11",
+					"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+					"integrity": "sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==",
+					"requires": {
+						"postcss": "^7.0.17",
+						"postcss-values-parser": "^2.0.1"
+					}
+				},
+				"postcss-custom-selectors": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+					"integrity": "sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==",
+					"requires": {
+						"postcss": "^7.0.2",
+						"postcss-selector-parser": "^5.0.0-rc.3"
+					},
+					"dependencies": {
+						"postcss-selector-parser": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+							"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+							"requires": {
+								"cssesc": "^2.0.0",
+								"indexes-of": "^1.0.1",
+								"uniq": "^1.0.1"
+							}
+						}
+					}
+				},
+				"postcss-font-variant": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz",
+					"integrity": "sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==",
+					"requires": {
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-initial": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-3.0.2.tgz",
+					"integrity": "sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==",
+					"requires": {
+						"lodash.template": "^4.5.0",
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-media-minmax": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+					"integrity": "sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==",
+					"requires": {
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-nesting": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
+					"integrity": "sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==",
+					"requires": {
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-pseudo-class-any-link": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+					"integrity": "sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==",
+					"requires": {
+						"postcss": "^7.0.2",
+						"postcss-selector-parser": "^5.0.0-rc.3"
+					},
+					"dependencies": {
+						"postcss-selector-parser": {
+							"version": "5.0.0",
+							"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+							"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+							"requires": {
+								"cssesc": "^2.0.0",
+								"indexes-of": "^1.0.1",
+								"uniq": "^1.0.1"
+							}
+						}
+					}
+				},
+				"postcss-replace-overflow-wrap": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+					"integrity": "sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==",
+					"requires": {
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-selector-matches": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+					"integrity": "sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-selector-not": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz",
+					"integrity": "sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==",
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"postcss": "^7.0.2"
+					}
+				},
+				"postcss-value-parser": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ=="
+				},
+				"postcss-values-parser": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+					"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
 					"requires": {
 						"flatten": "^1.0.2",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-pseudoelements": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-pseudoelements/-/postcss-pseudoelements-5.0.0.tgz",
-			"integrity": "sha1-7vGU6NUkZFylIKlJ6V5RjoEkAss=",
-			"requires": {
-				"postcss": "^6.0.0"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -6051,83 +5724,6 @@
 				"has": "^1.0.0",
 				"postcss": "^7.0.0",
 				"postcss-value-parser": "^3.0.0"
-			}
-		},
-		"postcss-replace-overflow-wrap": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-2.0.0.tgz",
-			"integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
-			"requires": {
-				"postcss": "^6.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-selector-matches": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz",
-			"integrity": "sha1-5WNAEeE5UIgYYbvdWMLQER/8lqs=",
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"postcss": "^6.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"postcss-selector-not": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-3.0.1.tgz",
-			"integrity": "sha1-Lk2y8JZTNsAefOx9tsYN/3ZzNdk=",
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"postcss": "^6.0.1"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "6.0.23",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-					"requires": {
-						"chalk": "^2.4.1",
-						"source-map": "^0.6.1",
-						"supports-color": "^5.4.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
 			}
 		},
 		"postcss-selector-parser": {
@@ -6165,16 +5761,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-		},
-		"postcss-values-parser": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-1.5.0.tgz",
-			"integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
-			"requires": {
-				"flatten": "^1.0.2",
-				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
-			}
 		},
 		"private": {
 			"version": "0.1.8",
@@ -6320,24 +5906,6 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
-		"reduce-css-calc": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"requires": {
-				"balanced-match": "^0.4.2",
-				"math-expression-evaluator": "^1.2.14",
-				"reduce-function-call": "^1.0.1"
-			}
-		},
-		"reduce-function-call": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
-			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"requires": {
-				"balanced-match": "^0.4.2"
-			}
-		},
 		"regenerate": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -6350,11 +5918,6 @@
 			"requires": {
 				"regenerate": "^1.4.0"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.0",
@@ -6426,11 +5989,6 @@
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-		},
 		"resolve": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -6453,16 +6011,6 @@
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-		},
-		"rgb": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/rgb/-/rgb-0.1.0.tgz",
-			"integrity": "sha1-vieykej+/+rBvZlylyG/pA/AN7U="
-		},
-		"rgb-hex": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/rgb-hex/-/rgb-hex-2.1.0.tgz",
-			"integrity": "sha1-x3PF/iJoolV42SU5qCp6XOU77aY="
 		},
 		"rgb-regex": {
 			"version": "1.0.1",
@@ -7261,15 +6809,6 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"units-css": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
-			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
-			"requires": {
-				"isnumeric": "^0.2.0",
-				"viewport-dimensions": "^0.2.0"
-			}
-		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7386,11 +6925,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
 			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
-		},
-		"viewport-dimensions": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
-			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w="
 		},
 		"vm-browserify": {
 			"version": "0.0.4",

--- a/packages/compiler/package-lock.json
+++ b/packages/compiler/package-lock.json
@@ -1156,6 +1156,11 @@
 			"resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
 			"integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
 		"@types/q": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
@@ -1347,6 +1352,33 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
 			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
+		},
+		"acorn-node": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+			"integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+			"requires": {
+				"acorn": "^7.0.0",
+				"acorn-walk": "^7.0.0",
+				"xtend": "^4.0.2"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+				},
+				"xtend": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+					"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+				}
+			}
+		},
+		"acorn-walk": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+			"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
 		},
 		"after": {
 			"version": "0.8.2",
@@ -1847,6 +1879,11 @@
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
 		},
+		"bytes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+		},
 		"cacache": {
 			"version": "11.3.2",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
@@ -1914,6 +1951,11 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+		},
+		"camelcase-css": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+			"integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="
 		},
 		"caniuse-api": {
 			"version": "3.0.0",
@@ -2561,6 +2603,11 @@
 				}
 			}
 		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+		},
 		"des.js": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -2568,6 +2615,16 @@
 			"requires": {
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"detective": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+			"integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+			"requires": {
+				"acorn-node": "^1.6.1",
+				"defined": "^1.0.0",
+				"minimist": "^1.1.1"
 			}
 		},
 		"diffie-hellman": {
@@ -4190,6 +4247,11 @@
 				"lodash._reinterpolate": "~3.0.0"
 			}
 		},
+		"lodash.toarray": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -4456,6 +4518,14 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
 			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
 		},
+		"node-emoji": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+			"integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+			"requires": {
+				"lodash.toarray": "^4.4.0"
+			}
+		},
 		"node-libs-browser": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
@@ -4515,6 +4585,11 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
 			"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+		},
+		"normalize.css": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
 		},
 		"nth-check": {
 			"version": "1.0.2",
@@ -5006,6 +5081,34 @@
 				"postcss": "^7.0.2"
 			}
 		},
+		"postcss-functions": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
+			"integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
+			"requires": {
+				"glob": "^7.1.2",
+				"object-assign": "^4.1.1",
+				"postcss": "^6.0.9",
+				"postcss-value-parser": "^3.3.0"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "6.0.23",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+					"integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+					"requires": {
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
+		},
 		"postcss-gap-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
@@ -5044,6 +5147,40 @@
 				"postcss-value-parser": "^3.2.3",
 				"read-cache": "^1.0.0",
 				"resolve": "^1.1.7"
+			}
+		},
+		"postcss-js": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
+			"integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
+			"requires": {
+				"camelcase-css": "^2.0.1",
+				"postcss": "^7.0.18"
+			},
+			"dependencies": {
+				"postcss": {
+					"version": "7.0.27",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+					"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+					"requires": {
+						"chalk": "^2.4.2",
+						"source-map": "^0.6.1",
+						"supports-color": "^6.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"postcss-lab-function": {
@@ -5762,6 +5899,11 @@
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
 			"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
 		},
+		"pretty-hrtime": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -5904,6 +6046,15 @@
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
+			}
+		},
+		"reduce-css-calc": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.7.tgz",
+			"integrity": "sha512-fDnlZ+AybAS3C7Q9xDq5y8A2z+lT63zLbynew/lur/IR24OQF5x98tfNwf79mzEdfywZ0a2wpM860FhFfMxZlA==",
+			"requires": {
+				"css-unit-converter": "^1.1.1",
+				"postcss-value-parser": "^3.3.0"
 			}
 		},
 		"regenerate": {
@@ -6584,6 +6735,183 @@
 				"stable": "^0.1.8",
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
+			}
+		},
+		"tailwindcss": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.2.0.tgz",
+			"integrity": "sha512-CKvY0ytB3ze5qvynG7qv4XSpQtFNGPbu9pUn8qFdkqgD8Yo/vGss8mhzbqls44YCXTl4G62p3qVZBj45qrd6FQ==",
+			"requires": {
+				"autoprefixer": "^9.4.5",
+				"bytes": "^3.0.0",
+				"chalk": "^3.0.0",
+				"detective": "^5.2.0",
+				"fs-extra": "^8.0.0",
+				"lodash": "^4.17.15",
+				"node-emoji": "^1.8.1",
+				"normalize.css": "^8.0.1",
+				"postcss": "^7.0.11",
+				"postcss-functions": "^3.0.0",
+				"postcss-js": "^2.0.0",
+				"postcss-nested": "^4.1.1",
+				"postcss-selector-parser": "^6.0.0",
+				"pretty-hrtime": "^1.0.3",
+				"reduce-css-calc": "^2.1.6",
+				"resolve": "^1.14.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+					"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"lodash": {
+					"version": "4.17.15",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+				},
+				"postcss-nested": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.1.tgz",
+					"integrity": "sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==",
+					"requires": {
+						"postcss": "^7.0.21",
+						"postcss-selector-parser": "^6.0.2"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "3.2.1",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+							"requires": {
+								"color-convert": "^1.9.0"
+							}
+						},
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							},
+							"dependencies": {
+								"supports-color": {
+									"version": "5.5.0",
+									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+									"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+									"requires": {
+										"has-flag": "^3.0.0"
+									}
+								}
+							}
+						},
+						"color-convert": {
+							"version": "1.9.3",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+							"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+							"requires": {
+								"color-name": "1.1.3"
+							}
+						},
+						"color-name": {
+							"version": "1.1.3",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+							"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+						},
+						"has-flag": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+							"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+						},
+						"postcss": {
+							"version": "7.0.27",
+							"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.27.tgz",
+							"integrity": "sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==",
+							"requires": {
+								"chalk": "^2.4.2",
+								"source-map": "^0.6.1",
+								"supports-color": "^6.1.0"
+							}
+						},
+						"supports-color": {
+							"version": "6.1.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+							"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"resolve": {
+					"version": "1.15.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+					"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"tapable": {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -24,7 +24,7 @@
     "@babel/preset-react": "^7.0.0",
     "acorn": "^6.1.1",
     "ansi-colors": "^3.2.4",
-    "autoprefixer": "^9.6.0",
+    "autoprefixer": "^9.7.4",
     "babel-loader": "^8.0.6",
     "clone": "^2.1.2",
     "css-loader": "^2.1.0",
@@ -36,16 +36,17 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "pocket.io": "^0.1.4",
     "postcss": "^7.0.17",
-    "postcss-cssnext": "^3.1.0",
     "postcss-discard-comments": "^4.0.2",
     "postcss-import": "^12.0.1",
     "postcss-loader": "^3.0.0",
     "postcss-nested": "^3.0.0",
+    "postcss-preset-env": "^6.7.0",
     "sass": "^1.21.0",
     "sass-loader": "^7.1.0",
     "socket.io": "^2.2.0",
     "style-loader": "^0.20.3",
     "webpack": "^4.33.0"
   },
-  "gitHead": "5068db0b2661b5e4a94a7a439e5919c4cc13c837"
+  "gitHead": "5068db0b2661b5e4a94a7a439e5919c4cc13c837",
+  "devDependencies": {}
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -45,6 +45,7 @@
     "sass-loader": "^7.1.0",
     "socket.io": "^2.2.0",
     "style-loader": "^0.20.3",
+    "tailwindcss": "^1.2.0",
     "webpack": "^4.33.0"
   },
   "gitHead": "5068db0b2661b5e4a94a7a439e5919c4cc13c837",

--- a/packages/compiler/presets/postcss.js
+++ b/packages/compiler/presets/postcss.js
@@ -13,6 +13,7 @@ module.exports = (options = {}) => {
           loader: require.resolve('postcss-loader'),
           options: {
             plugins: [
+              require('tailwindcss'),
               require('postcss-import'),
               require('postcss-nested'),
               require('postcss-preset-env')({

--- a/packages/compiler/presets/postcss.js
+++ b/packages/compiler/presets/postcss.js
@@ -15,10 +15,10 @@ module.exports = (options = {}) => {
             plugins: [
               require('postcss-import'),
               require('postcss-nested'),
-              require('postcss-cssnext')({
-                warnForDuplicates: false,
-                warnForDeprecations: false
+              require('postcss-preset-env')({
+                stage: 0
               }),
+              require('autoprefixer')
             ]
           }
         }

--- a/packages/slater/package-lock.json
+++ b/packages/slater/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "slater",
-	"version": "1.5.1",
+	"version": "1.7.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -4078,7 +4078,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4096,11 +4097,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4113,15 +4116,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4224,7 +4230,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4234,6 +4241,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4246,17 +4254,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4273,6 +4284,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4345,7 +4357,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4355,6 +4368,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4430,7 +4444,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4460,6 +4475,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4477,6 +4493,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4515,11 +4532,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/sync/package-lock.json
+++ b/packages/sync/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@slater/sync",
-	"version": "1.5.1",
+	"version": "1.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/util/package-lock.json
+++ b/packages/util/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@slater/util",
-	"version": "1.5.1",
+	"version": "1.6.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
`postcss-cssnext` is deprecated in favour of `postcss-preset-env`. I had to make this change locally to get things working with TailwindCSS, so having it in the official release would helpful!