### PR TITLE
Fixes #62 - Add multiple entry points support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -90,6 +90,16 @@
       ]
     },
     {
+      "login": "radmedov",
+      "name": "ray m",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/25644432?v=4",
+      "profile": "https://github.com/radmedov",
+      "contributions": [
+        "code",
+        "ideas"
+      ]
+    },
+    {
       "login": "mrtamagotchi",
       "name": "kotte",
       "avatar_url": "https://avatars1.githubusercontent.com/u/14197736?v=4",

--- a/packages/compiler/lib/createConfig.js
+++ b/packages/compiler/lib/createConfig.js
@@ -48,9 +48,10 @@ const baseConfig = {
 module.exports = function createConfig (conf, watch) {
   const wc = clone(baseConfig)
 
-  wc.entry = {
-    [path.basename(conf.in, '.js')]: path.resolve(cwd, conf.in)
-  }
+  wc.entry = (Array.isArray(conf.in) ? conf.in : [conf.in]).reduce((obj, entry) => {
+    obj[path.basename(entry, '.js')] = path.resolve(cwd, entry);
+    return obj;
+  },{});
 
   /**
    * merge output as an object,

--- a/packages/slater/index.js
+++ b/packages/slater/index.js
@@ -91,7 +91,7 @@ module.exports = function createApp (config) {
       console.log('')
 
       return new Promise((res, rej) => {
-        if (!fs.existsSync(abs(config.assets.in))) return
+        if (fs.existsSync(Array.isArray(config.assets.in) ? abs(config.assets.in[0]) : abs(config.assets.in))) return
 
         const bundle = compiler(config.assets)
 
@@ -209,7 +209,7 @@ module.exports = function createApp (config) {
         watchers.map(w => w.close())
       })
 
-      if (fs.existsSync(abs(config.assets.in))) {
+      if (fs.existsSync(Array.isArray(config.assets.in) ? abs(config.assets.in[0]) : abs(config.assets.in))) {
         const bundle = compiler(config.assets)
 
         bundle.on('error', e => {

--- a/packages/util/getConfig.js
+++ b/packages/util/getConfig.js
@@ -30,10 +30,10 @@ module.exports = function getConfig (options) {
     }
   }, require(configpath))
 
-  config.assets.alias = {
-    '@': abs(path.dirname(config.assets.in)),
-    ...(config.assets.alias || {})
-  }
+  config.assets.alias = (Array.isArray(config.assets.in) ? config.assets.in : [config.assets.in]).reduce((obj, entry) => {
+    obj['@'] = abs(path.dirname(entry));
+    return obj;
+  },{})
 
   if (!config.assets.presets) {
     config.assets.presets = [


### PR DESCRIPTION
Adds support of the multiple entry points.
Usage: 
```
assets: {
    in: ['./src/scripts/index.js', './src/scripts/cart.js'],
  },
```
Usage with single entry stays the same.

@iamkevingreen Please let me know if you have some comments on it and if it's even possible to add to Slater. This feature the only blocker for us to try moving our organization from Slate to Slater. 

Thank you.