### PR TITLE
Feature Proposition | Merge Webpack Config

### DIFF
--- a/packages/compiler/lib/createConfig.js
+++ b/packages/compiler/lib/createConfig.js
@@ -2,6 +2,8 @@ const path = require('path')
 const clone = require('clone')
 const webpack = require('webpack')
 
+const { merge } = require("webpack-merge")
+
 const cwd = process.cwd()
 
 const baseConfig = {
@@ -46,7 +48,7 @@ const baseConfig = {
 }
 
 module.exports = function createConfig (conf, watch) {
-  const wc = clone(baseConfig)
+  let wc = clone(baseConfig)
 
   wc.entry = {
     [path.basename(conf.in, '.js')]: path.resolve(cwd, conf.in)
@@ -92,6 +94,8 @@ module.exports = function createConfig (conf, watch) {
         )
       } catch (e) {}
     })
+
+  wc = merge(wc, conf.webpack || {})
 
   return wc
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -48,7 +48,8 @@
     "tailwindcss": "^1.2.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.5",
-    "webpack": "^4.33.0"
+    "webpack": "^4.33.0",
+    "webpack-merge": "^5.7.3"
   },
   "gitHead": "5068db0b2661b5e4a94a7a439e5919c4cc13c837"
 }

--- a/packages/slater/index.js
+++ b/packages/slater/index.js
@@ -93,7 +93,7 @@ module.exports = function createApp (config) {
       return new Promise((res, rej) => {
         if (!fs.existsSync(abs(config.assets.in))) return
 
-        const bundle = compiler(config.assets)
+        const bundle = compiler({ ...config.assets, webpack: config.webpack })
 
         bundle.on('error', e => {
           log.error(e)
@@ -210,7 +210,7 @@ module.exports = function createApp (config) {
       })
 
       if (fs.existsSync(abs(config.assets.in))) {
-        const bundle = compiler(config.assets)
+        const bundle = compiler({ ...config.assets, webpack: config.webpack })
 
         bundle.on('error', e => {
           log.error(e)


### PR DESCRIPTION
**Motivation**: 

- Some extra webpack configuration might be desirable for developers when working with **Slater**
- In our case - that was to have multiple entries files, to be used on different  Shopify layouts. For example,  `theme.js`  - for  `theme.liquid`, `checkout.js` for `checkout.liquid`
- Used [webpack-merge]( https://www.npmjs.com/package/webpack-merge) to allow to extend webpack configuration by simply adding `.webpack` property on `slater.config.js`

**Sample Config**: 
```
module.exports = {
  themes: {  //... },
  assets: {
    presets: ['sass']
  },
  webpack: {
    entry: {
      index: path.join(cwd, '/src/scripts/index.js'),
      checkout: path.join(cwd, '/src/scripts/checkout.js')
    },
    resolve: {
      alias: {
        jquery: 'jquery/src/jquery'
      }
    }
  }
};

```

**Notes**: 
- Have not deeply tested `webpack-merge` package - i.e how it would react to advanced configs merging. But I think that feature still can be useful for many developers, probably should be marked as advanced